### PR TITLE
Update 5ded6212-e8d4-4206-9025-cb5991bd2f80.md

### DIFF
--- a/en-us/OpenXMLCon/articles/5ded6212-e8d4-4206-9025-cb5991bd2f80.md
+++ b/en-us/OpenXMLCon/articles/5ded6212-e8d4-4206-9025-cb5991bd2f80.md
@@ -760,7 +760,7 @@ End Function
 
 ## See also
 
-#### Other resources
+#### Other resources 
 
 
  [Open XML SDK 2.5 class library reference](http://msdn.microsoft.com/library/36c8a76e-ce1b-5959-7e85-5d77db7f46d6(Office.15).aspx)


### PR DESCRIPTION
Using String.Compare will limit the usage until the column Z. If you replace it by the following code, it won't crash when we try to write after AA1 etc.. : "if (fromBase26(Regex.Replace(cell.CellReference.Value, @"[\d-]", string.Empty)) > fromBase26(Regex.Replace(address, @"[\d-]", string.Empty)))" and define "//Hexavigesimal (Excel Column Name to Number) - Bijective
        private int fromBase26(string colName)
        {
            colName = colName.ToUpper();
            int decimalValue = 0;
            for (int i = 0; i < colName.Length; i++)
            {
                decimalValue *= 26;
                decimalValue += (colName[i] - 64);
            }
            return decimalValue;
        }"