### PR TITLE
Corrects the complete sample code.

### DIFF
--- a/en-us/OpenXMLCon/articles/b3406fcc-f10b-4075-a18f-116400f35faf.md
+++ b/en-us/OpenXMLCon/articles/b3406fcc-f10b-4075-a18f-116400f35faf.md
@@ -150,7 +150,7 @@ Consider a paragraph in a WordprocessingML document which is centered, and this 
 
 The element specifies that there was a revision to the paragraph properties at 01-01-2006 by Samantha Smith, and the previous set of paragraph properties on the paragraph was the null set (in other words, no paragraph properties explicitly present under the element). **pPr** **pPrChange**
 
-© ISO/IEC29500: 2008.
+Â© ISO/IEC29500: 2008.
 
 <a name="sectionSection4" />
 
@@ -162,9 +162,9 @@ The following information from the  [ISO/IEC 29500](http://go.microsoft.com/fwli
 
 **del (Deleted Paragraph)**
 
-This element specifies that the paragraph mark delimiting the end of a paragraph within a WordprocessingML document shall be treated as deleted (in other words, the contents of this paragraph are no longer delimited by this paragraph mark, and are combined with the following paragraph—but those contents shall not automatically be marked as deleted) as part of a tracked revision.
+This element specifies that the paragraph mark delimiting the end of a paragraph within a WordprocessingML document shall be treated as deleted (in other words, the contents of this paragraph are no longer delimited by this paragraph mark, and are combined with the following paragraphâ€”but those contents shall not automatically be marked as deleted) as part of a tracked revision.
 
-Consider a document consisting of two paragraphs (with each paragraph delimited by a pilcrow ¶):
+Consider a document consisting of two paragraphs (with each paragraph delimited by a pilcrow Â¶):
 
 
 ![Two paragraphs each delimited by a pilcrow]
@@ -183,7 +183,7 @@ This revision is represented using the following WordprocessingML:
 <w:p>
   <w:pPr>
     <w:rPr>
-      <w:del w:id="0" … />
+      <w:del w:id="0" â€¦ />
     </w:rPr>
   </w:pPr>
   <w:r>
@@ -201,7 +201,7 @@ This revision is represented using the following WordprocessingML:
 
 The  **del** element on the run properties for the first paragraph mark specifies that this paragraph mark was deleted, and this deletion was tracked as a revision.
 
-© ISO/IEC29500: 2008.
+Â© ISO/IEC29500: 2008.
 
 <a name="sectionSection5" />
 
@@ -230,7 +230,7 @@ Consider a two row by two column table in which the second row has been marked a
   </w:tr>
   <w:tr>
     <w:trPr>
-      <w:ins w:id="0" … />
+      <w:ins w:id="0" â€¦ />
     </w:trPr>
     <w:tc>
       <w:p/>
@@ -246,7 +246,7 @@ Consider a two row by two column table in which the second row has been marked a
 
 The **ins** element on the table row properties for the second table row specifies that this row was inserted, and this insertion was tracked as a revision.
 
-© ISO/IEC29500: 2008.
+Â© ISO/IEC29500: 2008.
 
 <a name="sectionSection6" />
 
@@ -493,6 +493,7 @@ public static void AcceptRevisions(string fileName, string authorName)
         insertions.AddRange(body.Descendants<InsertedMathControl>()
             .Where(c => c.Author.Value == authorName).Cast<OpenXmlElement>().ToList());
 
+        Run lastInsertedRun = null;
         foreach (OpenXmlElement insertion in insertions)
         {
             // Found new content.
@@ -501,11 +502,11 @@ public static void AcceptRevisions(string fileName, string authorName)
             {
                 if (run == insertion.FirstChild)
                 {
-                    insertion.InsertAfterSelf(new Run(run.OuterXml));
+                    lastInsertedRun = insertion.InsertAfterSelf(new Run(run.OuterXml));
                 }
                 else
                 {
-                    insertion.NextSibling().InsertAfterSelf(new Run(run.OuterXml));
+                    lastInsertedRun = lastInsertedRun.InsertAfterSelf(new Run(run.OuterXml));
                 }
             }
             insertion.RemoveAttribute("rsidR", 
@@ -561,15 +562,16 @@ Public Sub AcceptRevisions(ByVal fileName As String, ByVal authorName As String)
 
         insertions.AddRange(body.Descendants(Of InsertedMathControl)() _
         .Where(Function(c) c.Author.Value = authorName).Cast(Of OpenXmlElement)().ToList())
-
+ 
+        Dim lastInsertedRun As Run = Nothing
         For Each insertion In insertions
             ' Found new content. Promote them to the same level as node, and then
             ' delete the node.
             For Each run In insertion.Elements(Of Run)()
                 If run Is insertion.FirstChild Then
-                    insertion.InsertAfterSelf(New Run(run.OuterXml))
+                    lastInsertedRun = insertion.InsertAfterSelf(New Run(run.OuterXml))
                 Else
-                    insertion.NextSibling().InsertAfterSelf(New Run(run.OuterXml))
+                    lastInsertedRun = lastInsertedRun.InsertAfterSelf(New Run(run.OuterXml))
                 End If
             Next
             insertion.RemoveAttribute("rsidR", _


### PR DESCRIPTION
When accepting insertions the order of the runs was incorrect (with more than two `Run` elements).