### PR TITLE
Correct 5ded6212-e8d4-4206-9025-cb5991bd2f80.md (Insert text into cell)

### DIFF
--- a/en-us/OpenXMLCon/articles/5ded6212-e8d4-4206-9025-cb5991bd2f80.md
+++ b/en-us/OpenXMLCon/articles/5ded6212-e8d4-4206-9025-cb5991bd2f80.md
@@ -610,7 +610,7 @@ The following is the complete sample code in both C# and Visual Basic.
                             refCell = cell;
                             break;
                     	}
-		    }
+                    }
                 }
 
                 Cell newCell = new Cell() { CellReference = cellReference };
@@ -741,9 +741,11 @@ Private Function InsertCellInWorksheet(ByVal columnName As String, ByVal rowInde
         ' Cells must be in sequential order according to CellReference. Determine where to insert the new cell.
         Dim refCell As Cell = Nothing
         For Each cell As Cell In row.Elements(Of Cell)()
-            If (String.Compare(cell.CellReference.Value, cellReference, True) > 0) Then
-                refCell = cell
-                Exit For
+            If (cell.CellReference.Value.Length == cellReference.Length)
+                If (String.Compare(cell.CellReference.Value, cellReference, True) > 0) Then
+                    refCell = cell
+                    Exit For
+                End If
             End If
         Next
 

--- a/en-us/OpenXMLCon/articles/5ded6212-e8d4-4206-9025-cb5991bd2f80.md
+++ b/en-us/OpenXMLCon/articles/5ded6212-e8d4-4206-9025-cb5991bd2f80.md
@@ -603,11 +603,14 @@ The following is the complete sample code in both C# and Visual Basic.
                 Cell refCell = null;
                 foreach (Cell cell in row.Elements<Cell>())
                 {
-                    if (string.Compare(cell.CellReference.Value, cellReference, true) > 0)
+                    if (cell.CellReference.Value.Length == cellReference.Length)
                     {
-                        refCell = cell;
-                        break;
-                    }
+                    	if (string.Compare(cell.CellReference.Value, cellReference, true) > 0)
+                    	{
+                            refCell = cell;
+                            break;
+                    	}
+		    }
                 }
 
                 Cell newCell = new Cell() { CellReference = cellReference };


### PR DESCRIPTION
Added an extra line of code to both the c# and vb sections to correct a bug that occurs when inserting a new cell with a column name greater than Z. The existing code mistakenly inserts cell AA1 in front of B1. The addition of the string length comparison ensures that the column string lengths are the same before sorting the strings.